### PR TITLE
feat: update default version for nfpm

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'nFPM - deb, rpm and apk packager'
-description: 'nFPM is a simple, 0-dependencies, deb, rpm and apk packager'
+name: 'nFPM - deb, rpm, apk and archlinux packager'
+description: 'nFPM is a simple, 0-dependencies, deb, rpm, apk and archlinux packager'
 branding:
   icon: 'package'
   color: 'purple'
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: ''
   packager:
-    description: 'Packager type: deb|rpm|apk'
+    description: 'Packager type: deb|rpm|apk|archlinux'
     required: true
     default: ''
   nfpm_version:

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   nfpm_version:
     description: 'nFPM version'
     required: false
-    default: '2.17.0'
+    default: 'v2.22.2'
 outputs:
   package:
     description: "Created package name"

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   nfpm_version:
     description: 'nFPM version'
     required: false
-    default: 'v2.22.2'
+    default: '2.22.2'
 outputs:
   package:
     description: "Created package name"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,5 +9,5 @@ if [ "$INPUT_CONFIG" != "" ] && [ "$INPUT_PACKAGER" != "" ]; then
     if [ "$name" = "" ]; then
         exit 1
     fi
-   echo "::set-output name=package::$name"
+   echo "{package}={$name}" >> $GITHUB_OUTPUT
 fi


### PR DESCRIPTION
Notable changes:

- update default nfpm version to 2.22.2
- replace deprecated set-output command
- add archlinux as a supported package type